### PR TITLE
New parameter old_crit2 with TRUE as default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pickmdl
 Type: Package
 Title: PICKMDL for RJDemetra
-Version: 0.6.0
-Date: 2024-10-25
+Version: 0.6.1
+Date: 2024-10-31
 Authors@R: c(person("Øyvind", "Langsrud", role = c("aut", "cre"), email = "oyl@ssb.no"),
              person("Dinh Quang", "Pham", role = c("aut")),
              person("Ane", "Seierstad", role = c("aut")),

--- a/R/crit_table.R
+++ b/R/crit_table.R
@@ -57,7 +57,10 @@ crit1 <- function(sa){
 #' @export
 crit2 <- function(sa){
   hj1 <- sa$regarima$residuals.stat$tests$P.value
-  hj1[4] 
+  if (isTRUE(getOption("pickmdl.old_crit2"))) {   # see ?x13_pickmdl
+    return(hj1[5])  # ljung box (residuals at seasonal lags)
+  }
+  hj1[4]   # ljung box
 }
 
 

--- a/R/x13_both.R
+++ b/R/x13_both.R
@@ -31,7 +31,8 @@ x13_both <- function(series, ..., userdefined = NULL, both_output = "main",
                         fastfirst = TRUE,
                         verbose = FALSE,
                         output = "sa",
-                        add_comment = TRUE){
+                        add_comment = TRUE,
+                        old_crit2 = TRUE){
   if(!(both_output %in% c("main", "spec", "both")))
     stop('Allowed values of parameter both_output are "main", "spec" and "both".')
   

--- a/R/x13_pickmdl.R
+++ b/R/x13_pickmdl.R
@@ -41,7 +41,12 @@
 #' @param add_comment When `TRUE`, a  comment attribute 
 #'      (character vector with `ok`, `ok_final` and `mdl_nr`) will 
 #'      be added to the \code{\link{x13}} output object. Use \code{\link{comment}} 
-#'      to get the attribute or \code{\link{ok}} to get the attribute converted to a list.     
+#'      to get the attribute or \code{\link{ok}} to get the attribute converted to a list. 
+#' @param old_crit2  Logical. The p-value criterion used for PICKMDL criterion number 2.
+#'       Set to `FALSE` for "Ljung-Box" and to `TRUE` for "Ljung-Box (residuals at seasonal lags)".
+#'       This parameter can be overridden by setting the `"pickmdl.old_crit2"` option,
+#'       in which case the option value will take precedence.
+#'
 #'
 #' @return By default an `x13` output object, or otherwise a list as specified by parameter `output`.
 #' @export
@@ -212,8 +217,18 @@ x13_pickmdl <- function(series, spec,
                         fastfirst = TRUE,
                         verbose = FALSE,
                         output = "sa",
-                        add_comment = TRUE) {
+                        add_comment = TRUE,
+                        old_crit2 = TRUE) {
   
+  original_option <- getOption("pickmdl.old_crit2")
+  
+  # Set the option to `old_crit2` only if it does not already exist
+  if (is.null(original_option)) {
+    options(pickmdl.old_crit2 = old_crit2)
+    
+    # Ensure that the option is removed when the function exits
+    on.exit(options(pickmdl.old_crit2 = NULL), add = TRUE)
+  }
   
   if (is.logical(corona)) {
     if (corona) {

--- a/man/x13_both.Rd
+++ b/man/x13_both.Rd
@@ -25,7 +25,8 @@ x13_both(
   fastfirst = TRUE,
   verbose = FALSE,
   output = "sa",
-  add_comment = TRUE
+  add_comment = TRUE,
+  old_crit2 = TRUE
 )
 }
 \arguments{
@@ -88,6 +89,11 @@ This affects the output when \code{output = "all"}.}
 (character vector with \code{ok}, \code{ok_final} and \code{mdl_nr}) will
 be added to the \code{\link{x13}} output object. Use \code{\link{comment}}
 to get the attribute or \code{\link{ok}} to get the attribute converted to a list.}
+
+\item{old_crit2}{Logical. The p-value criterion used for PICKMDL criterion number 2.
+Set to \code{FALSE} for "Ljung-Box" and to \code{TRUE} for "Ljung-Box (residuals at seasonal lags)".
+This parameter can be overridden by setting the \code{"pickmdl.old_crit2"} option,
+in which case the option value will take precedence.}
 }
 \value{
 By default an \code{x13} output object, or otherwise a list as specified by parameter \code{output} and \code{both_output}.

--- a/man/x13_pickmdl.Rd
+++ b/man/x13_pickmdl.Rd
@@ -25,7 +25,8 @@ x13_pickmdl(
   fastfirst = TRUE,
   verbose = FALSE,
   output = "sa",
-  add_comment = TRUE
+  add_comment = TRUE,
+  old_crit2 = TRUE
 )
 
 x13_automdl(..., automdl.enabled = TRUE)
@@ -90,6 +91,11 @@ This affects the output when \code{output = "all"}.}
 (character vector with \code{ok}, \code{ok_final} and \code{mdl_nr}) will
 be added to the \code{\link{x13}} output object. Use \code{\link{comment}}
 to get the attribute or \code{\link{ok}} to get the attribute converted to a list.}
+
+\item{old_crit2}{Logical. The p-value criterion used for PICKMDL criterion number 2.
+Set to \code{FALSE} for "Ljung-Box" and to \code{TRUE} for "Ljung-Box (residuals at seasonal lags)".
+This parameter can be overridden by setting the \code{"pickmdl.old_crit2"} option,
+in which case the option value will take precedence.}
 }
 \value{
 By default an \code{x13} output object, or otherwise a list as specified by parameter \code{output}.

--- a/tests/testthat/test-x13_pickmdl.R
+++ b/tests/testthat/test-x13_pickmdl.R
@@ -1,3 +1,7 @@
+
+# Tests made for new crit2
+options(pickmdl.old_crit2 = FALSE)
+
 test_that("x13_pickmdl works ok", {
   myseries <- pickmdl_data("myseries")
   


### PR DESCRIPTION
TRUE as default is temporary

Implemented via option named "pickmdl.old_crit2". See parameter documentation.